### PR TITLE
fix: use resource if var.create_global_resources

### DIFF
--- a/modules/deployment-process/data.tf
+++ b/modules/deployment-process/data.tf
@@ -3,8 +3,11 @@ locals {
   nr_entity_suffix = var.newrelic_resource_name_suffix != "" ? format("-%s", var.newrelic_resource_name_suffix) : ""
 
   # Provider is not able to search only one pool with the name, so we need this hack to search it ourselves
-  data_worker_pool  = { for worker in data.octopusdeploy_worker_pools.all.worker_pools : worker.name => worker }["${var.octopus_project_group_name}-workers-Ubuntu"]
-  data_all_projects = { for project in data.octopusdeploy_projects.all.projects : project.name => project }
+  data_worker_pool = { for worker in data.octopusdeploy_worker_pools.all.worker_pools : worker.name => worker }["${var.octopus_project_group_name}-workers-Ubuntu"]
+  data_all_projects = var.create_global_resources ? {
+    for project in octopusdeploy_project.all : project.name => project } : {
+    for project in data.octopusdeploy_projects.all.projects : project.name => project
+  }
 
 }
 


### PR DESCRIPTION
If we `var.create_global_resources` we do not want to fetch all projects with a datasource, but rather use the resources created.
If a new project is being created, the `octopusdeploy_deployment_process` fails because it was using the datasource and terraform cannot pass the dependency of a to-be-created project