### PR TITLE
Fix and create k8s configuration in k8s-connector

### DIFF
--- a/modules/k8s-connector/variables.tf
+++ b/modules/k8s-connector/variables.tf
@@ -39,6 +39,7 @@ variable "k8s_account_token" {
 variable "k8s_namespace" {
   description = "K8s account token"
   type        = string
+  default     = ""
 }
 
 variable "k8s_cluster_url" {

--- a/modules/k8s-connector/versions.tf
+++ b/modules/k8s-connector/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "OctopusDeployLabs/octopusdeploy"
       version = "0.22.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.31.0"
+    }
   }
 }


### PR DESCRIPTION
Changes: 
  - k8s_namespace is optional and can be created directly inside the module
  - Secrets, roles, service account, cluster role, and role binding can be created inside the module if the var k8s_account_token is empty in the module configuration

Fix:
 - Fix kubernetes_secret resource not creating correctly the secret

Why this update:
Remove any addicional k8s configuration outside the module configuration