### PR TITLE
add InterruptionView permission to developers role

### DIFF
--- a/modules/inception/main.tf
+++ b/modules/inception/main.tf
@@ -17,6 +17,7 @@ resource "octopusdeploy_user_role" "developers" {
     "DeploymentDelete",
     "DeploymentView",
     "EnvironmentView",
+    "InterruptionView",
     "FeedView",
     "LifecycleView",
     "MachinePolicyView",


### PR DESCRIPTION
This fix a missing permission when deploying.
![image](https://github.com/user-attachments/assets/e38dd336-98a7-47a6-995b-8afc7bc9fcfc)

