### PR TITLE
Move to the new OctopusDeploy provider for further fixes

### DIFF
--- a/modules/deployment-process/main.tf
+++ b/modules/deployment-process/main.tf
@@ -258,6 +258,15 @@ EOT
       }
     }
   }
+  /*
+  lifecycle {
+    ignore_changes = [ 
+      step[1].run_script_action[0].sort_order,
+      step[2].run_script_action[0].sort_order,
+      step[1].run_script_action[0].action_template
+    ]
+  }
+  */
 }
 
 #####

--- a/modules/deployment-process/versions.tf
+++ b/modules/deployment-process/versions.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     octopusdeploy = {
-      source  = "OctopusDeployLabs/octopusdeploy"
-      version = ">= 0.42.0"
+      source  = "OctopusDeploy/octopusdeploy"
+      version = ">= 1.0.1"
     }
     curl2 = {
       source  = "DanielKoehler/curl2"


### PR DESCRIPTION
Changes:
   - update to OctopusDeploy provider to version 1.0.1 (no breaking change)

On 1 June 2025, the Octopus Deploy Terraform Provider was promoted from a Labs project to a fully-supported, first-class Octopus Deploy integration.

As part of this promotion, we released [v1.0 of the provider](https://registry.terraform.io/providers/OctopusDeploy/octopusdeploy/1.0.0), and migrated the codebase from the OctopusDeployLabs GitHub organization to the OctopusDeploy organization. The provider also moved in the Hashicorp Terraform Registry.

New Repository: https://github.com/OctopusDeploy/

https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/issues/297#issuecomment-2938107036